### PR TITLE
create-envfileの手順を削除し、envとしてREACT_APP_YUMEMI_API_KEYを直接設定

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,22 +7,9 @@ on:
     branches: ["main"]
 
 jobs:
-  create-envfile:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Make envfile
-        uses: SpicyPizza/create-envfile@v2.0
-        with:
-          envkey_REACT_APP_YUMEMI_API_KEY: ${{ secrets.YUMEMI_API_KEY }}
-          directory: ./
-          file_name: .env
-          fail_on_empty: false
-          sort_keys: false
-
   build:
     name: build
     runs-on: ubuntu-latest
-    needs: create-envfile
     steps:
       - uses: actions/checkout@v3
       - name: yarn install
@@ -37,6 +24,8 @@ jobs:
         run: yarn lint
       - name: Run Jest
         run: yarn jest
+        env:
+          REACT_APP_YUMEMI_API_KEY: ${{ secrets.YUMEMI_API_KEY }}
       - name: Upload test coverage artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/deploy-ph-pages.yml
+++ b/.github/workflows/deploy-ph-pages.yml
@@ -16,24 +16,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  create-envfile:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Make envfile
-        uses: SpicyPizza/create-envfile@v2.0
-        with:
-          envkey_REACT_APP_YUMEMI_API_KEY: ${{ secrets.YUMEMI_API_KEY }}
-          directory: ./
-          file_name: .env
-          fail_on_empty: false
-          sort_keys: false
-
   build:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: create-envfile
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -50,6 +37,7 @@ jobs:
         run: yarn build
         env:
           GITHUB_PAGES: true
+          REACT_APP_YUMEMI_API_KEY: ${{ secrets.YUMEMI_API_KEY }}
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
# 実装内容
- create-envfileの手順を削除し、envとしてREACT_APP_YUMEMI_API_KEYを直接設定
  - Actions workflowからSpicyPizza/create-envfileを削除
  - テストおよびビルドステップでREACT_APP_YUMEMI_API_KEYを環境変数として直接渡すよう変更
  - GitHub Actionsでの.envファイル不要化とワークフロー簡略化